### PR TITLE
Handle dict-based pickle payloads in pkl_to_csv

### DIFF
--- a/pkl_to_csv.py
+++ b/pkl_to_csv.py
@@ -82,8 +82,14 @@ def main(
     unpickler = RobustUnpickler(f)
     data = unpickler.load()
 
-  frames = data.frames
-  fps = data.fps
+  if isinstance(data, dict):
+    frames = data["frames"]
+    fps = data["fps"]
+  else:
+    frames = data.frames
+    fps = data.fps
+
+  frames = np.asarray(frames)
   original_duration = frames.shape[0] / fps
 
   print(f"Loaded motion with shape: {frames.shape}")


### PR DESCRIPTION
Updated pkl_to_csv.py to support both dict-based and attribute-based pickle payloads.